### PR TITLE
Make (a)get return correct types and add (a)get_abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,16 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/svcs/compare/23.8.0...HEAD)
 
+### Changed
+
+- `Container.get()` and `Container.aget()` now have type hints that only work with concrete classes but allow for type checking without repeating yourself.
+  If you want to use abstract classes like `typing.Protocol` or ABCs, you can use `Container.get_abstract()` and `Container.aget_abstract()` instead.
+
+
 ### Added
+
+- `Container.get_abstract()` and `Container.aget_abstract()`.
+  They behave like `Container.get()` and `Container.aget()` before.
 
 - It is now possible to check if a service type is registered with a `Registry` by using `in`.
 

--- a/src/svcs/flask.py
+++ b/src/svcs/flask.py
@@ -9,15 +9,24 @@ from typing import Any, TypeVar, overload
 
 from flask import Flask, current_app, g, has_app_context
 
-from ._core import Container, Registry, ServicePing
+from ._core import (
+    T1,
+    T2,
+    T3,
+    T4,
+    T5,
+    T6,
+    T7,
+    T8,
+    T9,
+    T10,
+    Container,
+    Registry,
+    ServicePing,
+)
 
 
 FlaskAppT = TypeVar("FlaskAppT", bound=Flask)
-T1 = TypeVar("T1")
-T2 = TypeVar("T2")
-T3 = TypeVar("T3")
-T4 = TypeVar("T4")
-T5 = TypeVar("T5")
 
 
 def init_app(app: FlaskAppT, registry: Registry | None = None) -> FlaskAppT:
@@ -33,55 +42,6 @@ def init_app(app: FlaskAppT, registry: Registry | None = None) -> FlaskAppT:
     app.teardown_appcontext(teardown)
 
     return app
-
-
-@overload
-def get(svc_type: type[T1], /) -> T1:
-    ...
-
-
-@overload
-def get(svc_type1: type[T1], svc_type2: type[T2], /) -> tuple[T1, T2]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
-) -> tuple[T1, T2, T3]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    /,
-) -> tuple[T1, T2, T3, T4]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    /,
-) -> tuple[T1, T2, T3, T4, T5]:
-    ...
-
-
-def get(*svc_types: type) -> object:
-    """
-    Same as :meth:`svcs.Container.get()`, but uses container on :obj:`flask.g`.
-    """
-    _, container = _ensure_req_data()
-
-    return container.get(*svc_types)
 
 
 def get_abstract(*svc_types: type) -> Any:
@@ -199,3 +159,127 @@ def _ensure_req_data() -> tuple[Registry, Container]:
         g.svcs_container = Container(registry)
 
     return registry, g.svcs_container
+
+
+@overload
+def get(svc_type: type[T1], /) -> T1:
+    ...
+
+
+@overload
+def get(svc_type1: type[T1], svc_type2: type[T2], /) -> tuple[T1, T2]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
+) -> tuple[T1, T2, T3]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    /,
+) -> tuple[T1, T2, T3, T4]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    svc_type5: type[T5],
+    /,
+) -> tuple[T1, T2, T3, T4, T5]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    svc_type5: type[T5],
+    svc_type6: type[T6],
+    /,
+) -> tuple[T1, T2, T3, T4, T5, T6]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    svc_type5: type[T5],
+    svc_type6: type[T6],
+    svc_type7: type[T7],
+    /,
+) -> tuple[T1, T2, T3, T4, T5, T6, T7]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    svc_type5: type[T5],
+    svc_type6: type[T6],
+    svc_type7: type[T7],
+    svc_type8: type[T8],
+    /,
+) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    svc_type5: type[T5],
+    svc_type6: type[T6],
+    svc_type7: type[T7],
+    svc_type8: type[T8],
+    svc_type9: type[T9],
+    /,
+) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    svc_type5: type[T5],
+    svc_type6: type[T6],
+    svc_type7: type[T7],
+    svc_type8: type[T8],
+    svc_type9: type[T9],
+    svc_type10: type[T10],
+    /,
+) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]:
+    ...
+
+
+def get(*svc_types: type) -> object:
+    """
+    Same as :meth:`svcs.Container.get()`, but uses container on :obj:`flask.g`.
+    """
+    _, container = _ensure_req_data()
+
+    return container.get(*svc_types)

--- a/src/svcs/flask.py
+++ b/src/svcs/flask.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
 from flask import Flask, current_app, g, has_app_context
 
@@ -13,6 +13,11 @@ from ._core import Container, Registry, ServicePing
 
 
 FlaskAppT = TypeVar("FlaskAppT", bound=Flask)
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
 
 
 def init_app(app: FlaskAppT, registry: Registry | None = None) -> FlaskAppT:
@@ -30,13 +35,65 @@ def init_app(app: FlaskAppT, registry: Registry | None = None) -> FlaskAppT:
     return app
 
 
-def get(*svc_types: type) -> Any:
+@overload
+def get(svc_type: type[T1], /) -> T1:
+    ...
+
+
+@overload
+def get(svc_type1: type[T1], svc_type2: type[T2], /) -> tuple[T1, T2]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
+) -> tuple[T1, T2, T3]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    /,
+) -> tuple[T1, T2, T3, T4]:
+    ...
+
+
+@overload
+def get(
+    svc_type1: type[T1],
+    svc_type2: type[T2],
+    svc_type3: type[T3],
+    svc_type4: type[T4],
+    svc_type5: type[T5],
+    /,
+) -> tuple[T1, T2, T3, T4, T5]:
+    ...
+
+
+def get(*svc_types: type) -> object:
     """
     Same as :meth:`svcs.Container.get()`, but uses container on :obj:`flask.g`.
     """
     _, container = _ensure_req_data()
 
     return container.get(*svc_types)
+
+
+def get_abstract(*svc_types: type) -> Any:
+    """
+    Like :func:`get` but is annotated to return `Any` which allows it to be
+    used with abstract types like :class:`typing.Protocol` or :mod:`abc`
+    classes.
+
+    Note:
+        See https://github.com/python/mypy/issues/4717 why this is necessary.
+    """
+    return get(*svc_types)
 
 
 def register_factory(

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -39,7 +39,7 @@ def _container(clean_app_ctx):
 
 @pytest.mark.usefixtures("clean_app_ctx")
 class TestFlask:
-    def test_register_value_multiple(self, app, registry):
+    def test_register_value_multiple(self, registry):
         """
         register_value registers a service object on an app and get returns as
         many values as are requeste.
@@ -185,6 +185,19 @@ class TestFlask:
             "Skipped async cleanup for 'tests.ifaces.Service'. "
             "Use aclose() instead." == w.message.args[0]
         )
+
+    def test_register_factory_get_abstract(self, registry, container):
+        """
+        register_factory registers a factory and get_abstract returns the service.
+
+        The service is cached.
+        """
+        registry.register_factory(Interface, Service)
+
+        svc = container.get_abstract(Interface)
+
+        assert isinstance(svc, Interface)
+        assert svc is svcs.flask.get_abstract(Interface)
 
 
 class TestNonContextHelpers:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,7 @@ import pytest
 import svcs
 
 from .fake_factories import nop
-from .ifaces import AnotherService, Service, YetAnotherService
+from .ifaces import AnotherService, Interface, Service, YetAnotherService
 
 
 def test_register_factory_get(registry, container):
@@ -24,6 +24,20 @@ def test_register_factory_get(registry, container):
 
     assert isinstance(svc, Service)
     assert svc is container.get(Service)
+
+
+def test_register_factory_get_abstract(registry, container):
+    """
+    register_factory registers a factory and get_abstract returns the service.
+
+    The service is cached.
+    """
+    registry.register_factory(Interface, Service)
+
+    svc = container.get_abstract(Interface)
+
+    assert isinstance(svc, Interface)
+    assert svc is container.get(Interface)
 
 
 def test_register_value_multiple(registry, container):
@@ -202,6 +216,16 @@ class TestAsync:
 
         assert [42, 23] == (await container.aget(Service, AnotherService))
         assert [42, 23] == (await container.aget(Service, AnotherService))
+
+    async def test_aget_abstract_works_with_value(self, registry, container):
+        """
+        A value instead of a factory does not break aget_abstract().
+        """
+        registry.register_value(int, 42)
+        registry.register_value(str, "42")
+
+        assert [42, "42"] == (await container.aget_abstract(int, str))
+        assert [42, "42"] == (await container.aget_abstract(int, str))
 
     async def test_async_cleanup(self, registry, container):
         """

--- a/tests/typing/core.py
+++ b/tests/typing/core.py
@@ -20,7 +20,7 @@ with reg as reg:
     reg.register_factory(int, int)
 
 
-async def f() -> None:
+async def func() -> None:
     await reg.aclose()
     await con.aclose()
 
@@ -33,7 +33,14 @@ async def f() -> None:
             c: bool
             d: tuple
             e: object
-            a, b, c, d, e = await con2.aget(int, str, bool, tuple, object)
+            f: float
+            g: list
+            h: dict
+            i: set
+            j: bytes
+            a, b, c, d, e, f, g, h, i, j = await con2.aget(
+                int, str, bool, tuple, object, float, list, dict, set, bytes
+            )
 
 
 def gen() -> Generator:
@@ -78,7 +85,14 @@ b: str
 c: bool
 d: tuple
 e: object
-a, b, c, d, e = con.get(int, str, bool, tuple, object)
+f: float
+g: list
+h: dict
+i: set
+j: bytes
+a, b, c, d, e, f, g, h, i, j = con.get(
+    int, str, bool, tuple, object, float, list, dict, set, bytes
+)
 
 
 class P(Protocol):

--- a/tests/typing/core.py
+++ b/tests/typing/core.py
@@ -5,7 +5,7 @@
 import contextlib
 import sys
 
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator, Generator, Protocol
 
 import svcs
 
@@ -28,7 +28,12 @@ async def f() -> None:
         reg2.register_factory(int, int)
 
         async with svcs.Container(reg2) as con2:
-            await con2.aget(int)
+            a: int
+            b: str
+            c: bool
+            d: tuple
+            e: object
+            a, b, c, d, e = await con2.aget(int, str, bool, tuple, object)
 
 
 def gen() -> Generator:
@@ -66,9 +71,22 @@ con = svcs.Container(reg)
 
 # The type checker believes whatever we tell it.
 o1: object = con.get(object)
-o2: int = con.get(object)
+o2: int = con.get(int)
 
-o, i = con.get(object, int)
+a: int
+b: str
+c: bool
+d: tuple
+e: object
+a, b, c, d, e = con.get(int, str, bool, tuple, object)
+
+
+class P(Protocol):
+    def m(self) -> None:
+        ...
+
+
+p: P = con.get_abstract(P)
 
 con.close()
 

--- a/tests/typing/flask_.py
+++ b/tests/typing/flask_.py
@@ -32,11 +32,15 @@ svcs.flask.register_factory(app, str, str)
 svcs.flask.register_factory(app, int, factory_with_cleanup)
 svcs.flask.register_value(app, str, str, ping=lambda: None)
 
-# The type checker believes whatever we tell it.
 o1: object = svcs.flask.get(object)
-o2: int = svcs.flask.get(object)
 
-o1, o2 = svcs.flask.get(object, int)
+a: int
+b: str
+c: bool
+d: tuple
+e: object
+a, b, c, d, e = svcs.flask.get(int, str, bool, tuple, object)
+
 
 svcs.flask.close_registry(app)
 

--- a/tests/typing/flask_.py
+++ b/tests/typing/flask_.py
@@ -39,7 +39,14 @@ b: str
 c: bool
 d: tuple
 e: object
-a, b, c, d, e = svcs.flask.get(int, str, bool, tuple, object)
+f: float
+g: list
+h: dict
+i: set
+j: bytes
+a, b, c, d, e, f, g, h, i, j = svcs.flask.get(
+    int, str, bool, tuple, object, float, list, dict, set, bytes
+)
 
 
 svcs.flask.close_registry(app)


### PR DESCRIPTION
Unless someone brings up some _really_ good reasons, I've decided to allow for proper type-checking in the default methods and add the Any escape hatch to a pair of new methods called `get_abstract()` and `aget_abstract()`.

Having (a)get with a stricter set of APIs allows us to eventually just drop the abstract pair if Python typing ever adds a way for us to do this properly.

Now I know what @glyph meant by ugly type hints, too.