### PR TITLE
Use context managers to manage cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/svcs/compare/23.14.0...HEAD)
 
+### Changed
+
+- Cleanups for services are internally context managers now.
+  For your convenience, if you pass an (async) generator function for a factory, the registry will automatically wrap it for you into an (async) context manager.
+  [#92](https://github.com/hynek/svcs/pull/29)
+
 
 ## [23.14.0](https://github.com/hynek/svcs/compare/23.13.0...23.14.0) - 2023-08-11
 

--- a/conftest.py
+++ b/conftest.py
@@ -51,7 +51,7 @@ def _svc():
 
 @pytest.fixture(name="rs")
 def _rs(svc):
-    return svcs.RegisteredService(Service, Service, False, False, None)
+    return svcs.RegisteredService(Service, Service, False, None)
 
 
 @pytest.fixture(name="registry")

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -105,11 +105,13 @@ How to achieve this in other frameworks elegantly is TBD.
 
 ### Cleanup
 
-If a factory is a [generator](https://docs.python.org/3/tutorial/classes.html#generators) and *yields* the instance instead of returning it, the container will remember the generator.
-At the end, you run {meth}`svcs.Container.close()` and all generators will be finished (i.e. called `next(factory)` again).
+If a factory returns a [context manager](https://docs.python.org/3/library/stdtypes.html#context-manager-types), it will be immediately entered and the instance will be added to the cleanup list.
+If a factory is a [generator](https://docs.python.org/3/tutorial/classes.html#generators) that *yields* the instance instead of returning it, it will be wrapped in a context manager automatically.
+At the end, you run {meth}`svcs.Container.close()` and all context managers will be exited.
 You can use this to close files, return database connections to a pool, et cetera.
 
-If you have async generators, await {meth}`svcs.Container.aclose()` instead which calls `await anext(factory)` on all async generators (and `next(factory)` on sync ones).
+Async context managers and async generators work the same way.
+
 You can also use containers as (async) context managers that (a)close automatically on exit:
 
 ```python

--- a/docs/why.md
+++ b/docs/why.md
@@ -58,6 +58,20 @@ def cleanup():
 ```
 
 The generator-based setup and cleanup may remind you of [*pytest* fixtures](https://docs.pytest.org/en/stable/explanation/fixtures.html).
+However, internally *svcs* uses context managers to manage cleanups and transparently wraps your generators with {func}`~contextlib.contextmanager`.
+Therefore, you can *pass* a context manager as a factory, too and the following is equivalent to the above:
+
+% skip: next
+
+```python
+registry.register_factory(
+    Connection,
+    engine.connect,
+    ping=lambda conn: conn.execute(text("SELECT 1")),
+    on_registry_close=engine.dispose
+)
+```
+
 The callbacks defined as `on_registry_close` are called when you call `Registry.close()` -- for example, when your application is shutting down.
 
 Next, you can write a simple health check endpoint if you've registered health checks (called *pings*) for your services.

--- a/docs/why.md
+++ b/docs/why.md
@@ -58,15 +58,15 @@ def cleanup():
 ```
 
 The generator-based setup and cleanup may remind you of [*pytest* fixtures](https://docs.pytest.org/en/stable/explanation/fixtures.html).
-However, internally *svcs* uses context managers to manage cleanups and transparently wraps your generators with {func}`~contextlib.contextmanager`.
-Therefore, you can *pass* a context manager as a factory, too and the following is equivalent to the above:
+However, internally *svcs* uses context managers to manage cleanups, and if you pass a generator, it just wraps it with {func}`~contextlib.contextmanager` for your convenience.
+But of course, you can directly pass a context manager as a factory, too, and the following is equivalent to the above:
 
 % skip: next
 
 ```python
 registry.register_factory(
     Connection,
-    engine.connect,  # ← sqlalchemy.engine.Connection() is a context manager
+    engine.connect,  # ← sqlalchemy.engine.Connection is a context manager
     ping=lambda conn: conn.execute(text("SELECT 1")),
     on_registry_close=engine.dispose
 )

--- a/docs/why.md
+++ b/docs/why.md
@@ -64,12 +64,19 @@ But of course, you can directly pass a context manager as a factory, too, and th
 % skip: next
 
 ```python
+engine = create_engine("postgresql://localhost")
+
+registry = svcs.Registry()
 registry.register_factory(
     Connection,
-    engine.connect,  # ← sqlalchemy.engine.Connection is a context manager
+    engine.connect,  # ← sqlalchemy.Connection is a context manager
     ping=lambda conn: conn.execute(text("SELECT 1")),
     on_registry_close=engine.dispose
 )
+
+@atexit.register
+def cleanup():
+    registry.close()
 ```
 
 The callbacks defined as `on_registry_close` are called when you call `Registry.close()` -- for example, when your application is shutting down.

--- a/docs/why.md
+++ b/docs/why.md
@@ -66,7 +66,7 @@ Therefore, you can *pass* a context manager as a factory, too and the following 
 ```python
 registry.register_factory(
     Connection,
-    engine.connect,
+    engine.connect,  # ← sqlalchemy.engine.Connection() is a context manager
     ping=lambda conn: conn.execute(text("SELECT 1")),
     on_registry_close=engine.dispose
 )

--- a/tests/fake_factories.py
+++ b/tests/fake_factories.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-
 import asyncio
+
+from contextlib import asynccontextmanager, contextmanager
 
 
 def nop(*_, **__):
@@ -14,8 +15,13 @@ def int_factory():
     return 42
 
 
-def str_cleanup_factory():
+def str_gen_factory():
     yield "foo"
+
+
+@contextmanager
+def bool_cm_factory():
+    yield True
 
 
 async def async_int_factory():
@@ -23,7 +29,13 @@ async def async_int_factory():
     return 42
 
 
-async def async_str_cleanup_factory():
+async def async_str_gen_factory():
     await asyncio.sleep(0)
     yield str(42)
     await asyncio.sleep(0)
+
+
+@asynccontextmanager
+async def async_bool_cm_factory():
+    await asyncio.sleep(0)
+    yield True

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -6,7 +6,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from .ifaces import AnotherService, Service
+from .fake_factories import (
+    async_bool_cm_factory,
+    async_str_gen_factory,
+    bool_cm_factory,
+    str_gen_factory,
+)
+from .ifaces import AnotherService, Service, YetAnotherService
 
 
 class TestContainer:
@@ -38,20 +44,17 @@ class TestContainer:
         """
         The repr counts correctly.
         """
-
-        def factory():
-            yield 42
-
-        async def async_factory():
-            yield 42
-
-        registry.register_factory(Service, factory)
-        registry.register_factory(AnotherService, async_factory)
+        registry.register_factory(Service, str_gen_factory)
+        registry.register_factory(bool, bool_cm_factory)
+        registry.register_factory(AnotherService, async_str_gen_factory)
+        registry.register_factory(YetAnotherService, async_bool_cm_factory)
 
         container.get(Service)
+        container.get(bool)
         await container.aget(AnotherService)
+        await container.aget(YetAnotherService)
 
-        assert "<Container(instantiated=2, cleanups=2)>" == repr(container)
+        assert "<Container(instantiated=4, cleanups=4)>" == repr(container)
 
     def test_contains(self, container):
         """

--- a/tests/test_fake_factories.py
+++ b/tests/test_fake_factories.py
@@ -14,10 +14,10 @@ import pytest
 
 from .fake_factories import (
     async_int_factory,
-    async_str_cleanup_factory,
+    async_str_gen_factory,
     int_factory,
     nop,
-    str_cleanup_factory,
+    str_gen_factory,
 )
 
 
@@ -42,7 +42,7 @@ def test_str_cleanup_factory():
     str_cleanup_factory takes no arguments and returns a generator that yields
     a string.
     """
-    gen = str_cleanup_factory()
+    gen = str_gen_factory()
 
     assert isinstance(gen, Generator)
     assert isinstance(next(gen), str)
@@ -65,7 +65,7 @@ async def test_async_str_cleanup_factory():
     async_str_cleanup_factory takes no arguments and returns an async generator
     that yields a string.
     """
-    gen = async_str_cleanup_factory()
+    gen = async_str_gen_factory()
 
     assert isinstance(gen, AsyncGenerator)
     assert isinstance(await anext(gen), str)

--- a/tests/typing/core.py
+++ b/tests/typing/core.py
@@ -51,7 +51,17 @@ async def async_gen() -> AsyncGenerator:
     yield 42
 
 
+@contextlib.asynccontextmanager
+async def async_cm() -> AsyncGenerator:
+    yield 42
+
+
 def factory_with_cleanup() -> Generator[int, None, None]:
+    yield 1
+
+
+@contextlib.contextmanager
+def factory_with_cleanup_ctx() -> Generator[int, None, None]:
     yield 1
 
 
@@ -70,9 +80,11 @@ reg.register_value(int, gen)
 
 reg.register_factory(str, str)
 reg.register_factory(int, factory_with_cleanup)
+reg.register_factory(int, factory_with_cleanup_ctx)
 reg.register_factory(int, factory_with_cleanup, ping=async_ping)
+reg.register_factory(str, async_gen)
+reg.register_factory(str, async_cm)
 reg.register_value(str, str, ping=lambda: None)
-reg.register_value(str, async_gen)
 
 con = svcs.Container(reg)
 


### PR DESCRIPTION
Makes us better Python citizens and allows to pass context managers like `sqlalalchemy.Engine.connect` directly as factories.

Only downside is that we can't detect the async-ness of factories anymore because an async context manager function is a sync function that returns an async object…

Is this what you had in mind @RonnyPfannschmidt?