### PR TITLE
reduce overloads using `TypeVarTuple` and `Unpack`

### DIFF
--- a/docs/typing-caveats.md
+++ b/docs/typing-caveats.md
@@ -33,9 +33,3 @@ disable_error_code = ["type-abstract"]
 ```
 
 ... or by calling Mypy with the `--disable-error-code=type-abstract` argument.
-
-
-## Multiple Services
-
-Another caveat is that it's necessary to define multiple return values for `get()` for every single arity.
-We've done it for up to **ten service types** which should be plenty.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "attrs>=21.3.0", # attrs namespace
+  "typing-extensions; python_version<'3.11'",
 ]
 
 [project.optional-dependencies]
@@ -33,7 +34,6 @@ tests = [
   "pytest",
   "pytest-asyncio",
   "sybil",
-  "typing-extensions; python_version<'3.9'",
 ]
 typing = [
   "mypy>=1.4",

--- a/src/svcs/_core.py
+++ b/src/svcs/_core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import sys
 import warnings
 
 from collections.abc import Callable
@@ -28,6 +29,12 @@ from typing import Any, Awaitable, TypeVar, overload
 import attrs
 
 from .exceptions import ServiceNotFoundError
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import TypeVarTuple, Unpack
+else:
+    from typing import TypeVarTuple, Unpack
 
 
 log = logging.getLogger("svcs")
@@ -418,16 +425,8 @@ def _takes_container(factory: Callable) -> bool:
     return False
 
 
-T1 = TypeVar("T1")
-T2 = TypeVar("T2")
-T3 = TypeVar("T3")
-T4 = TypeVar("T4")
-T5 = TypeVar("T5")
-T6 = TypeVar("T6")
-T7 = TypeVar("T7")
-T8 = TypeVar("T8")
-T9 = TypeVar("T9")
-T10 = TypeVar("T10")
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
 
 
 @attrs.define
@@ -642,117 +641,11 @@ class Container:
         return False, svc, rs.name, rs.enter
 
     @overload
-    def get(self, svc_type: type[T1], /) -> T1:
+    def get(self, svc_type: type[T], /) -> T:
         ...
 
     @overload
-    def get(
-        self, svc_type1: type[T1], svc_type2: type[T2], /
-    ) -> tuple[T1, T2]:
-        ...
-
-    @overload
-    def get(
-        self, svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
-    ) -> tuple[T1, T2, T3]:
-        ...
-
-    @overload
-    def get(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        /,
-    ) -> tuple[T1, T2, T3, T4]:
-        ...
-
-    @overload
-    def get(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5]:
-        ...
-
-    @overload
-    def get(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6]:
-        ...
-
-    @overload
-    def get(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7]:
-        ...
-
-    @overload
-    def get(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]:
-        ...
-
-    @overload
-    def get(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-        ...
-
-    @overload
-    def get(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
-        svc_type10: type[T10],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]:
+    def get(self, *svc_types: Unpack[Ts]) -> tuple[Unpack[Ts]]:
         ...
 
     def get(self, *svc_types: type) -> object:
@@ -793,117 +686,11 @@ class Container:
         return rv
 
     @overload
-    async def aget(self, svc_type: type[T1], /) -> T1:
+    async def aget(self, svc_type: type[T], /) -> T:
         ...
 
     @overload
-    async def aget(
-        self, svc_type1: type[T1], svc_type2: type[T2], /
-    ) -> tuple[T1, T2]:
-        ...
-
-    @overload
-    async def aget(
-        self, svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
-    ) -> tuple[T1, T2, T3]:
-        ...
-
-    @overload
-    async def aget(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        /,
-    ) -> tuple[T1, T2, T3, T4]:
-        ...
-
-    @overload
-    async def aget(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5]:
-        ...
-
-    @overload
-    async def aget(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6]:
-        ...
-
-    @overload
-    async def aget(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7]:
-        ...
-
-    @overload
-    async def aget(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]:
-        ...
-
-    @overload
-    async def aget(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-        ...
-
-    @overload
-    async def aget(
-        self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
-        svc_type10: type[T10],
-        /,
-    ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]:
+    async def aget(self, *svc_types: Unpack[Ts]) -> tuple[Unpack[Ts]]:
         ...
 
     async def aget(self, *svc_types: type) -> object:

--- a/src/svcs/aiohttp.py
+++ b/src/svcs/aiohttp.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import sys
+
 from collections.abc import Callable
 from contextlib import suppress
 from typing import Any, overload
@@ -12,20 +14,13 @@ from aiohttp import web
 
 import svcs
 
-from ._core import (
-    _KEY_CONTAINER,
-    _KEY_REGISTRY,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-)
+from ._core import _KEY_CONTAINER, _KEY_REGISTRY, T, Ts
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Unpack
+else:
+    from typing import Unpack
 
 
 def svcs_from(request: web.Request) -> svcs.Container:
@@ -147,130 +142,14 @@ async def aget_abstract(request: web.Request, *svc_types: type) -> Any:
 
 
 @overload
-async def aget(request: web.Request, svc_type: type[T1], /) -> T1:
+async def aget(request: web.Request, svc_type: type[T], /) -> T:
     ...
 
 
 @overload
 async def aget(
-    request: web.Request, svc_type1: type[T1], svc_type2: type[T2], /
-) -> tuple[T1, T2]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    /,
-) -> tuple[T1, T2, T3]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    /,
-) -> tuple[T1, T2, T3, T4]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    /,
-) -> tuple[T1, T2, T3, T4, T5]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-    ...
-
-
-@overload
-async def aget(
-    request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]:
+    request: web.Request, *svc_types: Unpack[Ts]
+) -> tuple[Unpack[Ts]]:
     ...
 
 

--- a/src/svcs/flask.py
+++ b/src/svcs/flask.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import sys
+
 from collections.abc import Callable
 from typing import Any, TypeVar, cast, overload
 
@@ -14,20 +16,18 @@ from werkzeug.local import LocalProxy
 from ._core import (
     _KEY_CONTAINER,
     _KEY_REGISTRY,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
     Container,
     Registry,
     ServicePing,
+    T,
+    Ts,
 )
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Unpack
+else:
+    from typing import Unpack
 
 
 def svcs_from(g: _AppCtxGlobals = g) -> Container:
@@ -215,117 +215,12 @@ def close_registry(app: Flask) -> None:
 
 
 @overload
-def get(svc_type: type[T1], /) -> T1:
+def get(svc_type: type[T], /) -> T:
     ...
 
 
 @overload
-def get(svc_type1: type[T1], svc_type2: type[T2], /) -> tuple[T1, T2]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
-) -> tuple[T1, T2, T3]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    /,
-) -> tuple[T1, T2, T3, T4]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    /,
-) -> tuple[T1, T2, T3, T4, T5]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-    ...
-
-
-@overload
-def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]:
+def get(*svc_types: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     ...
 
 

--- a/src/svcs/pyramid.py
+++ b/src/svcs/pyramid.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import sys
+
 from collections.abc import Callable
 from contextlib import suppress
 from typing import Any, Protocol, overload
@@ -18,20 +20,13 @@ from pyramid.threadlocal import get_current_registry, get_current_request
 
 import svcs
 
-from ._core import (
-    _KEY_CONTAINER,
-    _KEY_REGISTRY,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-)
+from ._core import _KEY_CONTAINER, _KEY_REGISTRY, T, Ts
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Unpack
+else:
+    from typing import Unpack
 
 
 def svcs_from(request: Request | None = None) -> svcs.Container:
@@ -198,133 +193,12 @@ def get_abstract(request: Request, *svc_types: type) -> Any:
 
 
 @overload
-def get(request: Request, svc_type: type[T1], /) -> T1:
+def get(request: Request, svc_type: type[T], /) -> T:
     ...
 
 
 @overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    /,
-) -> tuple[T1, T2]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    /,
-) -> tuple[T1, T2, T3]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    /,
-) -> tuple[T1, T2, T3, T4]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    /,
-) -> tuple[T1, T2, T3, T4, T5]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-    ...
-
-
-@overload
-def get(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]:
+def get(request: Request, *svc_types: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     ...
 
 

--- a/src/svcs/starlette.py
+++ b/src/svcs/starlette.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import sys
 
 from typing import Any, AsyncGenerator, Callable, overload
 
@@ -17,20 +18,13 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 import svcs
 
-from svcs._core import (
-    _KEY_CONTAINER,
-    _KEY_REGISTRY,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-)
+from svcs._core import _KEY_CONTAINER, _KEY_REGISTRY, T, Ts
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Unpack
+else:
+    from typing import Unpack
 
 
 def svcs_from(request: Request) -> svcs.Container:
@@ -128,130 +122,12 @@ async def aget_abstract(request: Request, *svc_types: type) -> Any:
 
 
 @overload
-async def aget(request: Request, svc_type: type[T1], /) -> T1:
+async def aget(request: Request, svc_type: type[T], /) -> T:
     ...
 
 
 @overload
-async def aget(
-    request: Request, svc_type1: type[T1], svc_type2: type[T2], /
-) -> tuple[T1, T2]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    /,
-) -> tuple[T1, T2, T3]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    /,
-) -> tuple[T1, T2, T3, T4]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    /,
-) -> tuple[T1, T2, T3, T4, T5]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-    ...
-
-
-@overload
-async def aget(
-    request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
-    /,
-) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]:
+async def aget(request: Request, *svc_types: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     ...
 
 


### PR DESCRIPTION
# Summary

Reduce overloads for `get` and `aget` and allow an unlimited number of service types to be returned.

Uses [PEP 646 – Variadic Generics](https://peps.python.org/pep-0646/) which means `typing-extensions` is required for python versions below 3.11.

Opened as a draft as mypy doesn't support `TypeVarTuple` and `Unpack` yet but support has been merged https://github.com/python/mypy/pull/16354.

pyright has supported them for a while now.


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/svcs/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [ ] Typos aside (please, always submit typo fixes!), I understand that this pull request may be **closed** in case there was **no [previous discussion](https://github.com/hynek/svcs/discussions/categories/ideas)**.
- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests at <https://github.com/hynek/svcs/blob/main/tests/typing/>.
- [x] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/core-concepts.md` or one of the integration guides by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/svcs/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
