### PR TITLE
Stop rewriting class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Flask: `svcs.flask.registry` which is a `werkzeug.local.LocalProxy` for the currently active registry on `flask.current_app`.
 
 
+### Fixed
+
+- We've stopped rewriting the public names of our objects and `typing.get_type_hints()` now works on them as expected.
+  [#52](https://github.com/hynek/issues/pull/52)
+
+
 ## [23.20.0](https://github.com/hynek/svcs/compare/23.19.0...23.20.0) - 2023-09-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Fixed
 
-- We've stopped rewriting the public names of our objects and `typing.get_type_hints()` now works on them as expected.
+- We've stopped rewriting the public names of our objects and `typing.get_type_hints()` now works on them as expected for Python 3.10 and later.
   [#52](https://github.com/hynek/issues/pull/52)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - We've stopped rewriting the public names of our objects and `typing.get_type_hints()` now works on them as expected for Python 3.10 and later.
   [#52](https://github.com/hynek/issues/pull/52)
+  [#53](https://github.com/hynek/issues/pull/53)
 
 
 ## [23.20.0](https://github.com/hynek/svcs/compare/23.19.0...23.20.0) - 2023-09-05

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ if "dev" in release:
 exclude_patterns = ["_build"]
 
 nitpick_ignore = [
+    *[("py:class", f"svcs._core.T{i}") for i in range(1, 11)],
     # Welcome, MkDocs projects. :(
     ("py:class", "FastAPI"),
     ("py:class", "Starlette"),

--- a/src/svcs/__init__.py
+++ b/src/svcs/__init__.py
@@ -45,12 +45,3 @@ try:
     from . import starlette
 except ImportError:
     __all__ += ["starlette"]
-
-
-# Make nicer public names.
-__locals = locals()
-for __name in __all__:
-    if not __name.startswith("__") and not __name.islower():
-        __locals[__name].__module__ = "svcs"
-del __locals
-del __name  # pyright: ignore[reportUnboundVariable]

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -2,16 +2,25 @@
 #
 # SPDX-License-Identifier: MIT
 
+import sys
 import typing
+
+import pytest
 
 import svcs
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10+")
 def test_get_type_hints():
     """
-    typing.get_type_hints() works on our objects.
+    typing.get_type_hints() works on our objects on Python 3.10+.
+
+    Unfortunately supporting older versions would require to rewrite all type
+    hints.
 
     Regression test for #52.
     """
     typing.get_type_hints(svcs.Registry)
     typing.get_type_hints(svcs.Container)
+    typing.get_type_hints(svcs.ServicePing)
+    typing.get_type_hints(svcs.RegisteredService)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Hynek Schlawack <hs@ox.cx>
+#
+# SPDX-License-Identifier: MIT
+
+import typing
+
+import svcs
+
+
+def test_get_type_hints():
+    """
+    typing.get_type_hints() works on our objects.
+
+    Regression test for #52.
+    """
+    typing.get_type_hints(svcs.Registry)
+    typing.get_type_hints(svcs.Container)


### PR DESCRIPTION
Fixes #52

Um any idea why this is failing so weirdly on 3.8 and 3.9 @guacs?

```
________________________________________________________________ test_get_type_hints ________________________________________________________________

    def test_get_type_hints():
        """
        typing.get_type_hints() works on our objects.

        Regression test for #52.
        """
>       typing.get_type_hints(svcs.Registry)

tests/test_typing.py:16:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../.asdf/installs/python/3.9.17/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py:1459: in get_type_hints
    value = _eval_type(value, base_globals, localns)
../../.asdf/installs/python/3.9.17/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py:292: in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
../../.asdf/installs/python/3.9.17/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py:554: in _evaluate
    eval(self.__forward_code__, globalns, localns),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   TypeError: unsupported operand type(s) for |: 'ABCMeta' and '_SpecialGenericAlias'
```

Is this something I can do something about or can I gate it behind a version check?