### PR TITLE
Improve the handling of stringified annotations in `_takes_container`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 
+import importlib.util
+import sys
+
 from doctest import ELLIPSIS
 
 import pytest
@@ -65,3 +68,20 @@ def _container(registry):
 @pytest.fixture(name="close_me")
 def _close_me():
     return CloseMe()
+
+
+@pytest.fixture(name="create_module")
+def _create_module(tmp_path):
+    def wrapper(source):
+        module_name = "_svcs_testing_tmp_module"
+        module_path = tmp_path / f"{module_name}.py"
+        module_path.write_text(source)
+
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+
+        return module
+
+    return wrapper

--- a/conftest.py
+++ b/conftest.py
@@ -2,10 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-
-import importlib.util
-import sys
-
 from doctest import ELLIPSIS
 
 import pytest
@@ -68,20 +64,3 @@ def _container(registry):
 @pytest.fixture(name="close_me")
 def _close_me():
     return CloseMe()
-
-
-@pytest.fixture(name="create_module")
-def _create_module(tmp_path):
-    def wrapper(source):
-        module_name = "_svcs_testing_tmp_module"
-        module_path = tmp_path / f"{module_name}.py"
-        module_path.write_text(source)
-
-        spec = importlib.util.spec_from_file_location(module_name, module_path)
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
-
-        return module
-
-    return wrapper

--- a/src/svcs/_core.py
+++ b/src/svcs/_core.py
@@ -424,12 +424,12 @@ def _takes_container(factory: Callable) -> bool:
         raise TypeError(msg)
 
     ((name, p),) = tuple(sig.parameters.items())
-    annot = p.annotation
 
     return (
         name == "svcs_container"
-        or annot is Container
-        or annot == "svcs.Container"
+        or p.annotation is Container
+        or p.annotation == "svcs.Container"
+        or p.annotation == "Container"
     )
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -396,8 +396,10 @@ class TestTakesContainer:
         "module_source", takes_containers_annotation_string_modules
     )
     def test_annotation_str(self, module_source, create_module):
-        """Return `True` if the first argument is annotated as `svcs.Container`
-        using a string."""
+        """
+        Return `True` if the first argument is annotated as `svcs.Container`
+        using a string.
+        """
 
         module = create_module(module_source)
 


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/svcs/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Typos aside (please, always submit typo fixes!), I understand that this pull request may be **closed** in case there was **no [previous discussion](https://github.com/hynek/svcs/discussions/categories/ideas)**.
- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests at <https://github.com/hynek/svcs/blob/main/tests/typing/>.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/core-concepts.md` or one of the integration guides by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/svcs/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->

This should work in all the cases that are included in the tests, but it will still fail in the following case:
```python
from __future__ import annotations

from svcs import Container as ServiceContainer

def get_service(container: ServiceContainer) -> None:
    ...
```

This *can* be handled, but we would have to add something like [this](https://docs.litestar.dev/2/usage/routing/handlers.html#signature-namespace) to the `Registry` and then pass in that signature namespace mapping to `_takes_container` which would then pass it to the `locals` of `inspect.signature`.

Please let me know if there are any changes that needs to be made and I'd be happy to do so :)

NOTE: I haven't updated the changelog yet.
