### PR TITLE
Add container-local registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Added
 
+- Container-local registries!
+  Sometimes it's useful to bind a value or factory only to a container.
+  For example, request metadata or authentication information.
+
+  You can now achieve that with `svcs.Container.register_local_factory()` and `svcs.Container.register_local_value()`.
+  Once something local is registered, a registry is transparently created and it takes precedence over the global one when a service is requested.
+  The local registry is closed together with the container.
+
 - Flask: `svcs.flask.registry` which is a `werkzeug.local.LocalProxy` for the currently active registry on `flask.current_app`.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   You can now achieve that with `svcs.Container.register_local_factory()` and `svcs.Container.register_local_value()`.
   Once something local is registered, a registry is transparently created and it takes precedence over the global one when a service is requested.
   The local registry is closed together with the container.
+  [#56](https://github.com/hynek/issues/pull/56)
 
 - Flask: `svcs.flask.registry` which is a `werkzeug.local.LocalProxy` for the currently active registry on `flask.current_app`.
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -195,7 +195,7 @@ Sometimes, you want to register a factory or value that's only valid within a co
 For example, you might want to register the current request object such that other services can use its metadata.
 
 This is where container-local registries come in.
-They are created implicitly by calling `svcs.Container.register_local_factory()` and `svcs.Container.register_local_value()`.
+They are created implicitly by calling {meth}`svcs.Container.register_local_factory()` and {meth}`svcs.Container.register_local_value()`.
 When looking up factories in a container, the local registry takes precedence over the global one, and it is closed along with the container:
 
 ```python
@@ -329,7 +329,7 @@ You can see that the datetime factory and the str value have both been registere
    :members: register_factory, register_value, close, aclose, __contains__
 
 .. autoclass:: Container()
-   :members: get, aget, get_abstract, aget_abstract, close, aclose, get_pings, __contains__
+   :members: get, aget, get_abstract, aget_abstract, register_local_factory, register_local_value, close, aclose, get_pings, __contains__
 
 .. autoclass:: ServicePing()
    :members: name, ping, aping, is_async

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -194,7 +194,8 @@ That makes testing even easier because the business code makes fewer assumptions
 :::
 
 Sometimes, you want to register a factory or value that's only valid within a container.
-For example, you might want to register the current request object such that other services can use its metadata.
+For example, you might want to register a factory that depends on data from a request object.
+Per-request factories, if you will.
 
 This is where container-local registries come in.
 They are created implicitly by calling {meth}`svcs.Container.register_local_factory()` and {meth}`svcs.Container.register_local_value()`.
@@ -211,7 +212,7 @@ When looking up factories in a container, the local registry takes precedence ov
 ```
 
 ::: {warning}
-Nothing is going to stop you from letting your global factories depend on local ones.
+Nothing is going to stop you from letting your global factories depend on local ones -- similarly to template subclassing.
 
 For example, you could define your database connection like this:
 
@@ -235,7 +236,7 @@ def middleware(request):
     container.register_local_value(User, User(request.user_id, ...))
 ```
 
-However, then you have to be very careful around the caching of created services.
+**However**, then you have to be very careful around the caching of created services.
 If your application requests a `Connection` instance before you register the local `Request` factory, the `Connection` factory will either crash or be created with the wrong user (for example, if you defined a stub/fallback user in the global registry).
 
 It is safer and easier to reason about your code if you keep the dependency arrows point from the local registry to the global one:

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -259,10 +259,7 @@ def middleware(request):
 
     # Use a factory to keep the service lazy. If the view never asks for a
     # connection, we never connect -- or set a user.
-    container.register_local_factory(
-        ConnectionWithUserID,
-        set_user_id,
-    )
+    container.register_local_factory(ConnectionWithUserID, set_user_id)
 ```
 
 Now the type name expresses the purpose of the object and it doesn't matter if there's already a non-user-aware `Connection` in the global registry.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -185,6 +185,7 @@ That makes testing even easier because the business code makes fewer assumptions
 
 *svcs* will raise a {class}`ResourceWarning` if a container with pending cleanups is garbage-collected.
 
+(local-registries)=
 
 ### Container-Local Registries
 

--- a/src/svcs/_core.py
+++ b/src/svcs/_core.py
@@ -283,7 +283,7 @@ class Registry:
            )
 
         Please note that, unlike with :meth:`register_factory`, entering
-        context  managers is **disabled** by default.
+        context managers is **disabled** by default.
 
         .. versionchanged:: 23.21.0
            *enter* is now ``False`` by default.
@@ -682,6 +682,14 @@ class Container:
         on_registry_close: Callable | Awaitable | None = None,
     ) -> None:
         """
+        Same as :meth:`svcs.Registry.register_factory()`, but registers the
+        factory only for this container.
+
+        A temporary :class:`svcs.Registry` is transparently created and closed
+        together with the container the local factory has been registered on.
+
+        .. seealso:: :ref:`local-registries`
+
         .. versionadded:: 23.21.0
         """
         if self._lazy_local_registry is None:
@@ -705,6 +713,21 @@ class Container:
         on_registry_close: Callable | Awaitable | None = None,
     ) -> None:
         """
+        Syntactic sugar for::
+
+           register_local_factory(
+               svc_type,
+               lambda: value,
+               enter=enter,
+               ping=ping,
+               on_registry_close=on_registry_close
+           )
+
+        Please note that, unlike with :meth:`register_local_factory`, entering
+        context managers is **disabled** by default.
+
+        .. seealso:: :ref:`local-registries`
+
         .. versionadded:: 23.21.0
         """
         self.register_local_factory(

--- a/src/svcs/_core.py
+++ b/src/svcs/_core.py
@@ -685,8 +685,8 @@ class Container:
         Same as :meth:`svcs.Registry.register_factory()`, but registers the
         factory only for this container.
 
-        A temporary :class:`svcs.Registry` is transparently created and closed
-        together with the container the local factory has been registered on.
+        A temporary :class:`svcs.Registry` is transparently created -- and
+        closed together with the container it belongs to.
 
         .. seealso:: :ref:`local-registries`
 


### PR DESCRIPTION
This adds container-local registries as discussed in https://github.com/hynek/svcs/discussions/44.

It needs a bit more docs, but happy to hear feedback on the direction & design @aedify-swi and @Tinche!

Rendered docs: https://svcs--56.org.readthedocs.build/en/56/core-concepts.html#container-local-registries