### PR TITLE
Use flask app.extensions for storing registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Changed
 
-- In the flask integration, the `Registry` is now stored on `app.extensions`, not `app.config`. 
+- In the flask integration, the `Registry` is now stored on `app.extensions`, not `app.config`.
   This is an implementation detail.
   If you are directly accessing the registry via `app.config`, this is a breaking change, though you should ideally move to `svcs.flask.registry` anyway.
   [#71](https://github.com/hynek/svcs/discussions/71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Changed
 
-- In the flask integration, the `Registry` is now stored on `app.extensions`, not `app.config`.
+- Flask: The registry is now stored on `app.extensions`, not `app.config`.
   This is an implementation detail.
   If you are directly accessing the registry via `app.config`, this is a breaking change, though you should ideally move to `svcs.flask.registry` anyway.
   [#71](https://github.com/hynek/svcs/discussions/71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/svcs/compare/24.1.0...HEAD)
 
+### Changed
+
+- In the flask integration, the `Registry` is now stored on `app.extensions`, not `app.config`. 
+  This is an implementation detail.
+  If you are directly accessing the registry via `app.config`, this is a breaking change, though you should ideally move to `svcs.flask.registry` anyway.
+  [#71](https://github.com/hynek/svcs/discussions/71)
+  [#72](https://github.com/hynek/svcs/issues/72)
+  [#73](https://github.com/hynek/svcs/pull/73)
 
 ## [24.1.0](https://github.com/hynek/svcs/compare/23.21.0...24.1.0) - 2024-01-25
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -313,7 +313,7 @@ Now, you can point your monitoring tool of choice -- like Prometheus's [Blackbox
 
 While *svcs*'s core is entirely agnostic on how you use the registry and the container, all our {doc}`integrations/index` follow the same life cycle:
 
-- The {class}`svcs.Registry` objects live on **application-scoped** objects like {attr}`flask.Flask.config`.
+- The {class}`svcs.Registry` objects live on **application-scoped** objects like {attr}`flask.Flask.extensions`.
 - The {class}`svcs.Container` objects live on **request-scoped** objects like {data}`flask.g`.
 
 You're free to structure your own integrations as you want, though.

--- a/docs/integrations/flask.md
+++ b/docs/integrations/flask.md
@@ -1,6 +1,6 @@
 # Flask
 
-*svcs*'s [Flask](https://flask.palletsprojects.com/) integration uses the {attr}`flask.Flask.config` object to store the {class}`svcs.Registry` and the {obj}`~flask.g` object to store the {class}`svcs.Container`.
+*svcs*'s [Flask](https://flask.palletsprojects.com/) integration uses the {attr}`flask.Flask.extensions` object to store the {class}`svcs.Registry` and the {obj}`~flask.g` object to store the {class}`svcs.Container`.
 It also installs a {meth}`flask.Flask.teardown_appcontext` handler to close the container when the request is done.
 
 ---

--- a/docs/why.md
+++ b/docs/why.md
@@ -166,7 +166,7 @@ If you're curious, check the [glossary](glossary) entries for {term}`Service Loc
 While it may take a moment to realize, all of this comes with many benefits:
 
 **Reduction in boilerplate.**
-Every web framework has some way to store data on long-lived objects like the application, and short-lived objects like requests (for example, in Flask it's {attr}`flask.Flask.config` and {obj}`flask.g` – Starlette uses `request.state` for both).
+Every web framework has some way to store data on long-lived objects like the application, and short-lived objects like requests (for example, in Flask it's {attr}`flask.Flask.extensions` and {obj}`flask.g` – Starlette uses `request.state` for both).
 Some frameworks also have helpers to control the lifecycle of those objects (like {meth}`flask.Flask.teardown_appcontext` or {meth}`pyramid.request.Request.add_finished_callback`).
 But they work subtly differently and you accumulate a lot of repetitive boilerplate code.
 In fact, Hynek started this project because of the [repetitiveness of Flask's `get_X` pattern](#flask-get-x).

--- a/src/svcs/flask.py
+++ b/src/svcs/flask.py
@@ -35,7 +35,7 @@ def svcs_from(g: _AppCtxGlobals = g) -> Container:
     Get the current container from *g*.
     """
     if (con := g.get(_KEY_CONTAINER, None)) is None:
-        con = Container(current_app.config[_KEY_REGISTRY])
+        con = Container(current_app.extensions[_KEY_REGISTRY])
         setattr(g, _KEY_CONTAINER, con)
 
     return con  # type: ignore[no-any-return]
@@ -53,7 +53,7 @@ def get_registry(app: Flask | None = None) -> Registry:
     """
     if app is None:
         app = current_app
-    return app.config[_KEY_REGISTRY]  # type: ignore[no-any-return]
+    return app.extensions[_KEY_REGISTRY]  # type: ignore[no-any-return]
 
 
 registry = cast(Registry, LocalProxy(get_registry))
@@ -68,7 +68,7 @@ def init_app(app: FlaskAppT, *, registry: Registry | None = None) -> FlaskAppT:
 
     Creates a registry for you if you don't provide one.
     """
-    app.config[_KEY_REGISTRY] = registry or Registry()
+    app.extensions[_KEY_REGISTRY] = registry or Registry()
     app.teardown_appcontext(teardown)
 
     return app
@@ -95,7 +95,7 @@ def register_factory(
     Same as :meth:`svcs.Registry.register_factory()`, but uses registry on
     *app* that has been put there by :func:`init_app()`.
     """
-    app.config[_KEY_REGISTRY].register_factory(
+    app.extensions[_KEY_REGISTRY].register_factory(
         svc_type,
         factory,
         enter=enter,
@@ -117,7 +117,7 @@ def register_value(
     Same as :meth:`svcs.Registry.register_value()`, but uses registry on *app*
     that has been put there by :func:`init_app()`.
     """
-    app.config[_KEY_REGISTRY].register_value(
+    app.extensions[_KEY_REGISTRY].register_value(
         svc_type,
         value,
         enter=enter,
@@ -209,7 +209,7 @@ def close_registry(app: Flask) -> None:
     """
     Close the registry on *app*, if present.
     """
-    if reg := app.config.pop(_KEY_REGISTRY, None):
+    if reg := app.extensions.pop(_KEY_REGISTRY, None):
         reg.close()
 
 

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -263,7 +263,7 @@ class TestInitApp:
         app = flask.Flask("tests")
         svcs.flask.init_app(app)
 
-        assert isinstance(app.config["svcs_registry"], svcs.Registry)
+        assert isinstance(app.extensions["svcs_registry"], svcs.Registry)
 
     def test_explicit_registry(self):
         """
@@ -273,7 +273,7 @@ class TestInitApp:
         app = flask.Flask("tests")
         svcs.flask.init_app(app, registry=registry)
 
-        assert registry is app.config["svcs_registry"]
+        assert registry is app.extensions["svcs_registry"]
 
 
 class TestCloseRegistry:


### PR DESCRIPTION
# Summary

As discussed in #71 and #72, move registry from `app.config` to `app.extensions`

Flask provides [`app.extensions`][extensions] as a specific place for extensions to store state, and many flask extensions do that (e.g. Flask-SQLAlchemy). This seems like the right place to store `svcs` state.

`app.config` is usually filled with things which might be set from an external `config.py` file, environment variable, or some other source. I often even like to be able to render these things back to e.g. JSON to save the current configuration for debugging.

[extensions]: https://flask.palletsprojects.com/en/3.0.x/api/#flask.Flask.extensions

# Pull Request Check List

- [X] Typos aside (please, always submit typo fixes!), I understand that this pull request may be **closed** in case there was **no [previous discussion](https://github.com/hynek/svcs/discussions/categories/ideas)**.
- [X] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [X] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [X] **New APIs** are added to our typing tests at <https://github.com/hynek/svcs/blob/main/tests/typing/>.
- [X] Updated **documentation** for changed code.
    - [-] New functions/classes have to be added to `docs/core-concepts.md` or one of the integration guides by hand.
    - [-] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [X] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/svcs/blob/main/CHANGELOG.md).
- [X] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

