### PR TITLE
Add preliminary Python 3.13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Check public API with Mypy
+        if: ${{ matrix.python-version != '3.13' }}
         run: |
           python -Im tox run \
             --installpkg dist/*.whl \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Typing :: Typed",
 ]
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ env_list =
     pyright,
     py3{8,9,10,11,12}-mypy
     py3{8,9,10,11,12}-tests{,-optional},
+    py313-tests,  # Deps aren't there, yet.
     coverage-report
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ env_list =
     pyright,
     py3{8,9,10,11,12}-mypy
     py3{8,9,10,11,12}-tests{,-optional},
-    py313-tests,  # Deps aren't there, yet.
+    py313-tests,  # Deps aren't there, yet. Remove Mypy if-block from ci.yml once they are, too!
     coverage-report
 
 


### PR DESCRIPTION
We have to skip the optional dependencies for now, since PyO3 (and others) aren't there yet.