### PR TITLE
Use PEP 735 / dependency groups in tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "attrs>=21.3.0", # attrs namespace
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 docs = [
   "sphinx>=7.2.2",
   "sphinx-design",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 [tox]
-min_version = 4
+min_version = 4.22
 env_list =
     pre-commit,
     docs,
@@ -21,11 +21,10 @@ pass_env = SETUPTOOLS_SCM_PRETEND_VERSION
 [testenv]
 package = wheel
 wheel_build_env = .pkg
-extras =
+dependency_groups =
     tests: tests
     mypy: typing
 deps =
-    mypy: mypy
     tests: coverage[toml]
     optional: aiohttp
     optional: fastapi
@@ -56,20 +55,20 @@ commands = pre-commit run --all-files
 
 [testenv:mypy-pkg]
 description = Type-check the package.
-extras = typing
+dependency_groups = typing
 commands = mypy src
 
 
 [testenv:pyright]
 deps = pyright
-extras = typing
+dependency_groups = typing
 commands = pyright tests/typing src
 
 
 [testenv:docs]
 # Keep base_python in sync with ci.yml/docs and .readthedocs.yaml.
 base_python = py312
-extras = docs
+dependency_groups = docs
 commands =
     sphinx-build -n -T -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -n -T -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
@@ -80,7 +79,7 @@ commands =
 [testenv:docs-watch]
 package = editable
 base_python = {[testenv:docs]base_python}
-extras = {[testenv:docs]extras}
+dependency_groups = {[testenv:docs]extras}
 deps = watchfiles
 commands =
     watchfiles \
@@ -94,5 +93,5 @@ commands =
 
 [testenv:docs-linkcheck]
 base_python = {[testenv:docs]base_python}
-extras = {[testenv:docs]extras}
+dependency_groups = {[testenv:docs]extras}
 commands = sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/html


### PR DESCRIPTION
We can't merge it before at least one installer supports it, though. Otherwise, there would be no way to install a local dev environment (currently `pip install -e .[dev]`).