### PR TITLE
Use TypeForm instead of type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Check public API with Mypy
+        if: matrix.python-version != '3.15'
         run: >
           uvx --with tox-uv tox run
           --installpkg dist/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.16
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,20 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/svcs/compare/25.1.0...HEAD)
 
+### Deprecated
+
+- `svcs.get_abstract()` and all its `*_abstract()` siblings.
+  Thanks to [PEP 747] they are no longer necessary.
+
+[PEP 747]: https://peps.python.org/pep-0747/
+
 ### Added
 
-- Python 3.14 support.
+- Python 3.14 and 3.15 support.
+
+- [PEP 747] support, aka [`typing.TypeForm`](https://docs.python.org/3.15/library/typing.html#typing.TypeForm).
+  This means that it's now possible use abstract types like `Protocol`s or abstract base classes for registered services, removing an important typing caveat.
+  This change introduces a dependency on `typing-extensions` for Python 3.14 and earlier.
 
 - New *suppress_context_exit* argument to `svcs.register_(factory|value)()`.
   If set to `False`, errors in the container context will be passed into the factory cleanup context manager and allow you to act on them there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - `svcs.get_abstract()` and all its `*_abstract()` siblings.
   Thanks to [PEP 747] they are no longer necessary.
+  No deprecation warnings or plans to remove them for now.
 
 [PEP 747]: https://peps.python.org/pep-0747/
+
 
 ### Added
 
@@ -29,6 +31,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - [PEP 747] support, aka [`typing.TypeForm`](https://docs.python.org/3.15/library/typing.html#typing.TypeForm).
   This means that it's now possible use abstract types like `Protocol`s or abstract base classes for registered services, removing an important typing caveat.
   This change introduces a dependency on `typing-extensions` for Python 3.14 and earlier.
+
+  Note: Mypy users that want to take advantage of this must pass the `--enable-incomplete-feature=TypeForm` argument for the time being.
+  Since the [PR to activate it has been merged](https://github.com/python/mypy/pull/21262), we expect it to land in Mypy 2.2.
 
 - New *suppress_context_exit* argument to `svcs.register_(factory|value)()`.
   If set to `False`, errors in the container context will be passed into the factory cleanup context manager and allow you to act on them there.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ exclude_patterns = ["_build"]
 nitpick_ignore = [
     ("py:class", "SomeLifespan"),  # just a type alias
     *[("py:class", f"svcs._core.T{i}") for i in range(1, 11)],
+    ("py:class", "typing_extensions.TypeForm"),
     # This only fails in CI!?
     *[("py:class", f"T{i}") for i in range(1, 11)],
     # Welcome, MkDocs projects. :(

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -258,8 +258,6 @@ Dependency Inversion Principle
     Nobody will stop you from passing a Mock where a Django `QuerySet` is expected.
 
     ::: {seealso}
-    - {doc}`typing-caveats` regarding abstract classes and *svcs*.
-
     - <https://en.wikipedia.org/wiki/Dependency_inversion_principle>
 
     - The third chapter of the wonderful [*Architecture Patterns with Python*] book called [*On Coupling and Abstractions*](https://www.cosmicpython.com/book/chapter_03_abstractions.html) (you can read it for free on the web).

--- a/docs/typing-caveats.md
+++ b/docs/typing-caveats.md
@@ -1,41 +1,6 @@
 # Typing Caveats
 
-## Abstract Classes and PEP 544
-
-If you try to `get()` an abstract class like an `Protocol` or an *abstract base class* you'll get a Mypy error like this:
-
-```text
-error: Only concrete class can be given where "type[P]" is expected  [type-abstract]
-```
-
-Unfortunately, it's [impossible](https://github.com/python/mypy/issues/4717) to type-hint `type[P]` when `P` is abstract because it's forbidden by {pep}`544`.
-
-As a stopgap, until we get something better in Python typing, *svcs* comes with `Container.get_abstract()` and `Container.aget_abstract()` that are type-hinted to return {obj}`~typing.Any`.
-Since `Any` disables any kind of type-checking, you have to use it like this:
-
-% skip: start
-
-```python
-ac: SomeAbstractClass = container.get_abstract(SomeAbstractClass)
-```
-
-You can also create bespoke wrappers for your services:
-
-```python
-def get_connection() -> Connection:
-    return svcs.flask.get_abstract(Connection)
-```
-
-Finally, you can disable this error by adding the following line to your Mypy configuration:
-
-```toml
-disable_error_code = ["type-abstract"]
-```
-
-... or by calling Mypy with the `--disable-error-code=type-abstract` argument.
-
-
 ## Multiple Services
 
-Another caveat is that it's necessary to define multiple return values for `get()` for every single arity.
+It's necessary to define multiple return values for `get()` for every single arity.
 We've done it for up to **ten service types** which should be plenty.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Typing :: Typed",
 ]
 keywords = [
@@ -36,6 +37,7 @@ keywords = [
 ]
 dependencies = [
   "attrs>=21.3.0", # attrs namespace
+  "typing_extensions>=4.13.0; python_version < '3.15'", # TypeForm
 ]
 
 [dependency-groups]
@@ -72,8 +74,6 @@ typing = [
 dev = [
   { include-group = "tests" },
   { include-group = "typing" },
-  # Dependency groups; let it decide on minimum tox version.
-  "tox-uv>=1.16.0",
   "httpx",
 ]
 

--- a/src/svcs/_core.py
+++ b/src/svcs/_core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import sys
 import warnings
 
 from collections.abc import Awaitable, Callable, Iterator
@@ -24,12 +25,21 @@ from inspect import (
     isgeneratorfunction,
 )
 from types import TracebackType
-from typing import Any, TypeVar, overload
+from typing import Any, TypeAlias, TypeVar, overload
 from unittest.mock import MagicMock
 
 import attrs
 
 from .exceptions import ServiceNotFoundError
+
+
+if sys.version_info < (3, 15):
+    from typing_extensions import TypeForm as TypeForm  # noqa: PLC0414
+else:
+    from typing import TypeForm as TypeForm  # noqa: PLC0414
+
+
+_ServiceType: TypeAlias = TypeForm[Any]
 
 
 log = logging.getLogger("svcs")
@@ -73,7 +83,7 @@ class RegisteredService:
             exiting registered factories.
     """
 
-    svc_type: type
+    svc_type: _ServiceType
     factory: Callable = attrs.field(hash=False)
     takes_container: bool
     enter: bool
@@ -143,7 +153,7 @@ class ServicePing:
 
     name: str
     is_async: bool
-    _svc_type: type
+    _svc_type: _ServiceType
     _ping: Callable
     _container: Container
 
@@ -197,7 +207,7 @@ class Registry:
             If a registry with pending cleanups is garbage-collected.
     """
 
-    _services: dict[type, RegisteredService] = attrs.Factory(dict)
+    _services: dict[_ServiceType, RegisteredService] = attrs.Factory(dict)
     _on_close: list[tuple[RegisteredService, Callable | Awaitable]] = (
         attrs.Factory(list)
     )
@@ -205,7 +215,7 @@ class Registry:
     def __repr__(self) -> str:
         return f"<svcs.Registry(num_services={len(self._services)})>"
 
-    def __contains__(self, svc_type: type) -> bool:
+    def __contains__(self, svc_type: _ServiceType) -> bool:
         """
         Check whether this registry knows how to create *svc_type*:
 
@@ -264,7 +274,7 @@ class Registry:
 
     def register_factory(
         self,
-        svc_type: type,
+        svc_type: _ServiceType,
         factory: Callable,
         *,
         enter: bool = True,
@@ -360,7 +370,7 @@ class Registry:
 
     def register_value(
         self,
-        svc_type: type,
+        svc_type: _ServiceType,
         value: object,
         *,
         enter: bool = False,
@@ -404,7 +414,7 @@ class Registry:
 
     def _register_factory(
         self,
-        svc_type: type,
+        svc_type: _ServiceType,
         factory: Callable,
         enter: bool,
         ping: Callable | None,
@@ -429,7 +439,9 @@ class Registry:
             self._on_close.append((rs, on_registry_close))
         return rs
 
-    def get_registered_service_for(self, svc_type: type) -> RegisteredService:
+    def get_registered_service_for(
+        self, svc_type: _ServiceType
+    ) -> RegisteredService:
         try:
             return self._services[svc_type]
         except KeyError:
@@ -587,7 +599,7 @@ class Container:
 
     registry: Registry
     _lazy_local_registry: Registry | None = None
-    _instantiated: dict[type, tuple[object, RegisteredService]] = (
+    _instantiated: dict[_ServiceType, tuple[object, RegisteredService]] = (
         attrs.Factory(dict)
     )
     _on_close: list[
@@ -603,7 +615,7 @@ class Container:
             f"cleanups={len(self._on_close)})>"
         )
 
-    def __contains__(self, svc_type: type) -> bool:
+    def __contains__(self, svc_type: _ServiceType) -> bool:
         """
         Check whether this container has a cached instance of *svc_type*.
         """
@@ -760,29 +772,32 @@ class Container:
         )
         return pings
 
-    def get_abstract(self, *svc_types: type) -> Any:
+    def get_abstract(self, *svc_types: _ServiceType) -> Any:
         """
         Like :meth:`get` but is annotated to return :data:`typing.Any` which
-        allows it to be used with abstract types like :class:`typing.Protocol`
-        or :mod:`abc` classes.
+        used to be the only way to allow it to be used with abstract types like
+        :class:`typing.Protocol` or :mod:`abc` classes.
 
-        Note:
-             See :doc:`typing-caveats` why this is necessary.
+        As of *svcs* 26.1.0 and :pep:`747`, this is no longer necessary.
+
+        .. deprecated:: 26.1.0
         """
         return self.get(*svc_types)
 
-    async def aget_abstract(self, *svc_types: type) -> Any:
+    async def aget_abstract(self, *svc_types: _ServiceType) -> Any:
         """
         Same as :meth:`get_abstract` but instantiates asynchronously, if
         necessary.
 
         Also works with synchronous services, so in an async application, just
         use this.
+
+        .. deprecated:: 26.1.0
         """
         return await self.aget(*svc_types)
 
     def _lookup(
-        self, svc_type: type
+        self, svc_type: _ServiceType
     ) -> tuple[bool, object, RegisteredService]:
         """
         Look up svc_type first in our cache, then in the registry.
@@ -809,7 +824,7 @@ class Container:
 
     def register_local_factory(
         self,
-        svc_type: type,
+        svc_type: _ServiceType,
         factory: Callable,
         *,
         enter: bool = True,
@@ -841,7 +856,7 @@ class Container:
 
     def register_local_value(
         self,
-        svc_type: type,
+        svc_type: _ServiceType,
         value: object,
         *,
         enter: bool = False,
@@ -876,110 +891,114 @@ class Container:
         )
 
     @overload
-    def get(self, svc_type: type[T1], /) -> T1: ...
+    def get(self, svc_type: TypeForm[T1], /) -> T1: ...
 
     @overload
     def get(
-        self, svc_type1: type[T1], svc_type2: type[T2], /
+        self, svc_type1: TypeForm[T1], svc_type2: TypeForm[T2], /
     ) -> tuple[T1, T2]: ...
 
     @overload
     def get(
-        self, svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
+        self,
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        /,
     ) -> tuple[T1, T2, T3]: ...
 
     @overload
     def get(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
         /,
     ) -> tuple[T1, T2, T3, T4]: ...
 
     @overload
     def get(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
         /,
     ) -> tuple[T1, T2, T3, T4, T5]: ...
 
     @overload
     def get(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6]: ...
 
     @overload
     def get(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7]: ...
 
     @overload
     def get(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
+        svc_type8: TypeForm[T8],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
     @overload
     def get(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
+        svc_type8: TypeForm[T8],
+        svc_type9: TypeForm[T9],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
     @overload
     def get(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
-        svc_type10: type[T10],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
+        svc_type8: TypeForm[T8],
+        svc_type9: TypeForm[T9],
+        svc_type10: TypeForm[T10],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]: ...
 
-    def get(self, *svc_types: type) -> object:
+    def get(self, *svc_types: _ServiceType) -> object:
         """
         Get services of *svc_types*.
 
@@ -1021,110 +1040,114 @@ class Container:
         return rv
 
     @overload
-    async def aget(self, svc_type: type[T1], /) -> T1: ...
+    async def aget(self, svc_type: TypeForm[T1], /) -> T1: ...
 
     @overload
     async def aget(
-        self, svc_type1: type[T1], svc_type2: type[T2], /
+        self, svc_type1: TypeForm[T1], svc_type2: TypeForm[T2], /
     ) -> tuple[T1, T2]: ...
 
     @overload
     async def aget(
-        self, svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
+        self,
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        /,
     ) -> tuple[T1, T2, T3]: ...
 
     @overload
     async def aget(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
         /,
     ) -> tuple[T1, T2, T3, T4]: ...
 
     @overload
     async def aget(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
         /,
     ) -> tuple[T1, T2, T3, T4, T5]: ...
 
     @overload
     async def aget(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6]: ...
 
     @overload
     async def aget(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7]: ...
 
     @overload
     async def aget(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
+        svc_type8: TypeForm[T8],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
     @overload
     async def aget(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
+        svc_type8: TypeForm[T8],
+        svc_type9: TypeForm[T9],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
     @overload
     async def aget(
         self,
-        svc_type1: type[T1],
-        svc_type2: type[T2],
-        svc_type3: type[T3],
-        svc_type4: type[T4],
-        svc_type5: type[T5],
-        svc_type6: type[T6],
-        svc_type7: type[T7],
-        svc_type8: type[T8],
-        svc_type9: type[T9],
-        svc_type10: type[T10],
+        svc_type1: TypeForm[T1],
+        svc_type2: TypeForm[T2],
+        svc_type3: TypeForm[T3],
+        svc_type4: TypeForm[T4],
+        svc_type5: TypeForm[T5],
+        svc_type6: TypeForm[T6],
+        svc_type7: TypeForm[T7],
+        svc_type8: TypeForm[T8],
+        svc_type9: TypeForm[T9],
+        svc_type10: TypeForm[T10],
         /,
     ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]: ...
 
-    async def aget(self, *svc_types: type) -> object:
+    async def aget(self, *svc_types: _ServiceType) -> object:
         """
         Same as :meth:`get` but instantiates asynchronously, if necessary.
 

--- a/src/svcs/_core.py
+++ b/src/svcs/_core.py
@@ -182,7 +182,7 @@ class ServicePing:
 
 @attrs.define
 class Registry:
-    """
+    r"""
     A central registry of recipes for creating services.
 
     An instance of this should live as long as your application does.
@@ -205,6 +205,10 @@ class Registry:
     Warns:
         ResourceWarning:
             If a registry with pending cleanups is garbage-collected.
+
+    .. versionadded:: 26.1.0
+       It is now possible to register (and get) abstract types like
+       :class:`typing.Protocol`\ s or abstract base classes.
     """
 
     _services: dict[_ServiceType, RegisteredService] = attrs.Factory(dict)

--- a/src/svcs/aiohttp.py
+++ b/src/svcs/aiohttp.py
@@ -25,6 +25,8 @@ from ._core import (
     T8,
     T9,
     T10,
+    TypeForm,
+    _ServiceType,
 )
 
 
@@ -88,7 +90,7 @@ async def svcs_middleware(
 
 def register_value(
     app: web.Application,
-    svc_type: type,
+    svc_type: _ServiceType,
     value: object,
     *,
     enter: bool = False,
@@ -110,7 +112,7 @@ def register_value(
 
 def register_factory(
     app: web.Application,
-    svc_type: type,
+    svc_type: _ServiceType,
     factory: Callable,
     *,
     enter: bool = True,
@@ -155,30 +157,35 @@ def get_pings(request: web.Request) -> list[svcs.ServicePing]:
     return svcs_from(request).get_pings()
 
 
-async def aget_abstract(request: web.Request, *svc_types: type) -> Any:
+async def aget_abstract(request: web.Request, *svc_types: _ServiceType) -> Any:
     """
     Same as :meth:`svcs.Container.aget_abstract()`, but uses container from
     *request*.
+
+    .. deprecated:: 26.1.0
     """
     return await svcs_from(request).aget_abstract(*svc_types)
 
 
 @overload
-async def aget(request: web.Request, svc_type: type[T1], /) -> T1: ...
+async def aget(request: web.Request, svc_type: TypeForm[T1], /) -> T1: ...
 
 
 @overload
 async def aget(
-    request: web.Request, svc_type1: type[T1], svc_type2: type[T2], /
+    request: web.Request,
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    /,
 ) -> tuple[T1, T2]: ...
 
 
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
     /,
 ) -> tuple[T1, T2, T3]: ...
 
@@ -186,10 +193,10 @@ async def aget(
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
     /,
 ) -> tuple[T1, T2, T3, T4]: ...
 
@@ -197,11 +204,11 @@ async def aget(
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
     /,
 ) -> tuple[T1, T2, T3, T4, T5]: ...
 
@@ -209,12 +216,12 @@ async def aget(
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6]: ...
 
@@ -222,13 +229,13 @@ async def aget(
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7]: ...
 
@@ -236,14 +243,14 @@ async def aget(
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
@@ -251,15 +258,15 @@ async def aget(
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
@@ -267,21 +274,21 @@ async def aget(
 @overload
 async def aget(
     request: web.Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
+    svc_type10: TypeForm[T10],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]: ...
 
 
-async def aget(request: web.Request, *svc_types: type) -> object:
+async def aget(request: web.Request, *svc_types: _ServiceType) -> object:
     """
     Same as :meth:`svcs.Container.aget`, but uses the container from *request*.
     """

--- a/src/svcs/flask.py
+++ b/src/svcs/flask.py
@@ -27,6 +27,8 @@ from ._core import (
     Container,
     Registry,
     ServicePing,
+    TypeForm,
+    _ServiceType,
 )
 
 
@@ -74,17 +76,19 @@ def init_app(app: FlaskAppT, *, registry: Registry | None = None) -> FlaskAppT:
     return app
 
 
-def get_abstract(*svc_types: type) -> Any:
+def get_abstract(*svc_types: _ServiceType) -> Any:
     """
     Same as :meth:`svcs.Container.get_abstract()`, but uses container on
     :obj:`flask.g`.
+
+    .. deprecated:: 26.1.0
     """
     return get(*svc_types)
 
 
 def register_factory(
     app: Flask,
-    svc_type: type,
+    svc_type: _ServiceType,
     factory: Callable,
     *,
     enter: bool = True,
@@ -106,7 +110,7 @@ def register_factory(
 
 def register_value(
     app: Flask,
-    svc_type: type,
+    svc_type: _ServiceType,
     value: object,
     *,
     enter: bool = False,
@@ -127,7 +131,7 @@ def register_value(
 
 
 def overwrite_factory(
-    svc_type: type,
+    svc_type: _ServiceType,
     factory: Callable,
     *,
     enter: bool = True,
@@ -156,7 +160,7 @@ def overwrite_factory(
 
 
 def overwrite_value(
-    svc_type: type,
+    svc_type: _ServiceType,
     value: object,
     *,
     enter: bool = True,
@@ -214,111 +218,116 @@ def close_registry(app: Flask) -> None:
 
 
 @overload
-def get(svc_type: type[T1], /) -> T1: ...
-
-
-@overload
-def get(svc_type1: type[T1], svc_type2: type[T2], /) -> tuple[T1, T2]: ...
+def get(svc_type: TypeForm[T1], /) -> T1: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1], svc_type2: type[T2], svc_type3: type[T3], /
+    svc_type1: TypeForm[T1], svc_type2: TypeForm[T2], /
+) -> tuple[T1, T2]: ...
+
+
+@overload
+def get(
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    /,
 ) -> tuple[T1, T2, T3]: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
     /,
 ) -> tuple[T1, T2, T3, T4]: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
     /,
 ) -> tuple[T1, T2, T3, T4, T5]: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6]: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7]: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
 
 @overload
 def get(
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
+    svc_type10: TypeForm[T10],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]: ...
 
 
-def get(*svc_types: type) -> object:
+def get(*svc_types: _ServiceType) -> object:
     """
     Same as :meth:`svcs.Container.get()`, but uses container on :obj:`flask.g`.
     """

--- a/src/svcs/pyramid.py
+++ b/src/svcs/pyramid.py
@@ -31,6 +31,8 @@ from ._core import (
     T8,
     T9,
     T10,
+    TypeForm,
+    _ServiceType,
 )
 
 
@@ -117,7 +119,7 @@ class ServicesTween:
 
 def register_factory(
     config: PyramidRegistryHaver,
-    svc_type: type,
+    svc_type: _ServiceType,
     factory: Callable,
     *,
     enter: bool = True,
@@ -139,7 +141,7 @@ def register_factory(
 
 def register_value(
     config: PyramidRegistryHaver,
-    svc_type: type,
+    svc_type: _ServiceType,
     value: object,
     *,
     enter: bool = False,
@@ -192,23 +194,25 @@ def get_pings(request: Request) -> list[svcs.ServicePing]:
     return svcs_from(request).get_pings()
 
 
-def get_abstract(request: Request, *svc_types: type) -> Any:
+def get_abstract(request: Request, *svc_types: _ServiceType) -> Any:
     """
     Same as :meth:`svcs.Container.get_abstract()`, but uses container from
     *request*.
+
+    .. deprecated:: 26.1.0
     """
     return svcs_from(request).get(*svc_types)
 
 
 @overload
-def get(request: Request, svc_type: type[T1], /) -> T1: ...
+def get(request: Request, svc_type: TypeForm[T1], /) -> T1: ...
 
 
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
     /,
 ) -> tuple[T1, T2]: ...
 
@@ -216,9 +220,9 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
     /,
 ) -> tuple[T1, T2, T3]: ...
 
@@ -226,10 +230,10 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
     /,
 ) -> tuple[T1, T2, T3, T4]: ...
 
@@ -237,11 +241,11 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
     /,
 ) -> tuple[T1, T2, T3, T4, T5]: ...
 
@@ -249,12 +253,12 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6]: ...
 
@@ -262,13 +266,13 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7]: ...
 
@@ -276,14 +280,14 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
@@ -291,15 +295,15 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
@@ -307,21 +311,21 @@ def get(
 @overload
 def get(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
+    svc_type10: TypeForm[T10],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]: ...
 
 
-def get(request: Request, *svc_types: type) -> object:
+def get(request: Request, *svc_types: _ServiceType) -> object:
     """
     Same as :meth:`svcs.Container.get()`, but uses thread locals to find the
     current request.

--- a/src/svcs/starlette.py
+++ b/src/svcs/starlette.py
@@ -31,6 +31,8 @@ from svcs._core import (
     T8,
     T9,
     T10,
+    TypeForm,
+    _ServiceType,
 )
 
 
@@ -124,30 +126,35 @@ def get_pings(request: Request) -> list[svcs.ServicePing]:
     return svcs_from(request).get_pings()
 
 
-async def aget_abstract(request: Request, *svc_types: type) -> Any:
+async def aget_abstract(request: Request, *svc_types: _ServiceType) -> Any:
     """
     Same as :meth:`svcs.Container.aget_abstract()`, but uses container from
     *request*.
+
+    .. deprecated:: 26.1.0
     """
     return await svcs_from(request).aget_abstract(*svc_types)
 
 
 @overload
-async def aget(request: Request, svc_type: type[T1], /) -> T1: ...
+async def aget(request: Request, svc_type: TypeForm[T1], /) -> T1: ...
 
 
 @overload
 async def aget(
-    request: Request, svc_type1: type[T1], svc_type2: type[T2], /
+    request: Request,
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    /,
 ) -> tuple[T1, T2]: ...
 
 
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
     /,
 ) -> tuple[T1, T2, T3]: ...
 
@@ -155,10 +162,10 @@ async def aget(
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
     /,
 ) -> tuple[T1, T2, T3, T4]: ...
 
@@ -166,11 +173,11 @@ async def aget(
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
     /,
 ) -> tuple[T1, T2, T3, T4, T5]: ...
 
@@ -178,12 +185,12 @@ async def aget(
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6]: ...
 
@@ -191,13 +198,13 @@ async def aget(
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7]: ...
 
@@ -205,14 +212,14 @@ async def aget(
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
@@ -220,15 +227,15 @@ async def aget(
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
@@ -236,21 +243,21 @@ async def aget(
 @overload
 async def aget(
     request: Request,
-    svc_type1: type[T1],
-    svc_type2: type[T2],
-    svc_type3: type[T3],
-    svc_type4: type[T4],
-    svc_type5: type[T5],
-    svc_type6: type[T6],
-    svc_type7: type[T7],
-    svc_type8: type[T8],
-    svc_type9: type[T9],
-    svc_type10: type[T10],
+    svc_type1: TypeForm[T1],
+    svc_type2: TypeForm[T2],
+    svc_type3: TypeForm[T3],
+    svc_type4: TypeForm[T4],
+    svc_type5: TypeForm[T5],
+    svc_type6: TypeForm[T6],
+    svc_type7: TypeForm[T7],
+    svc_type8: TypeForm[T8],
+    svc_type9: TypeForm[T9],
+    svc_type10: TypeForm[T10],
     /,
 ) -> tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]: ...
 
 
-async def aget(request: Request, *svc_types: type) -> object:
+async def aget(request: Request, *svc_types: _ServiceType) -> object:
     """
     Same as :meth:`svcs.Container.aget`, but uses the container from *request*.
     """

--- a/tests/typing/core.py
+++ b/tests/typing/core.py
@@ -3,11 +3,18 @@
 # SPDX-License-Identifier: MIT
 
 import contextlib
+import sys
 
 from collections.abc import AsyncGenerator, Generator
 from typing import Protocol
 
 import svcs
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import assert_type
+else:
+    from typing import assert_type
 
 
 reg = svcs.Registry()
@@ -115,6 +122,9 @@ class P(Protocol):
     def m(self) -> None: ...
 
 
+p_from_get: P = con.get(P)
+
+assert_type(p_from_get, P)
 p: P = con.get_abstract(P)
 
 con.close()

--- a/tests/typing/starlette.py
+++ b/tests/typing/starlette.py
@@ -56,7 +56,7 @@ reg = svcs.Registry()
 
 app = Starlette(
     lifespan=lifespan,
-    middleware=[Middleware(svcs.starlette.SVCSMiddleware)],  # ty: ignore[invalid-argument-type] https://github.com/astral-sh/ty/issues/1635
+    middleware=[Middleware(svcs.starlette.SVCSMiddleware)],
 )
 
 a: int

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,8 @@ deps =
     ty: ty
 commands =
     # Mypy API checks need to happen per-Python version.
-    mypy: mypy --enable-incomplete-feature=TypeForm src
+    # For some reason, this env poisons the cache, so we use a separate one.
+    mypy: mypy --cache-dir={env_tmp_dir}/mypy_cache --enable-incomplete-feature=TypeForm src
     pyrefly: pyrefly check --remove-unused-ignores
     pyright: pyright tests/typing src
     ty: ty check

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ env_list =
     typing-{mypy,pyright,ty,pyrefly},
     3.{10-14}-mypy
     3.{10-14}-tests{,-optional},
+    3.15-tests,
     coverage-{combine,report}
 
 
@@ -38,11 +39,7 @@ deps =
     optional: starlette
 commands =
     tests: coverage run -m pytest {posargs}
-    mypy: mypy tests/typing docs/examples/fastapi/simple_fastapi_app.py docs/examples/starlette/simple_starlette_app.py
-
-[testenv:3.14-mypy]
-commands =
-    mypy tests/typing/core.py tests/typing/flask.py tests/typing/aiohttp.py tests/typing/pyramid.py tests/typing/starlette.py docs/examples/starlette/simple_starlette_app.py
+    mypy: mypy --enable-incomplete-feature=TypeForm tests/typing/core.py tests/typing/flask.py tests/typing/aiohttp.py tests/typing/pyramid.py tests/typing/starlette.py docs/examples/starlette/simple_starlette_app.py
 
 
 # Split combine/report in 2 to avoid excessive "Combined data file ..." output.
@@ -79,7 +76,7 @@ deps =
     ty: ty
 commands =
     # Mypy API checks need to happen per-Python version.
-    mypy: mypy src
+    mypy: mypy --enable-incomplete-feature=TypeForm src
     pyrefly: pyrefly check --remove-unused-ignores
     pyright: pyright tests/typing src
     ty: ty check


### PR DESCRIPTION
With special thanks to @jukkaL for hands-on assistance at PyCon US.

Diff is big, but mostly a search-and-replace.

What is odd, is how the `typing-mypy` tox environment somehow poisons .mypy_cache that then doesn't look at the current type hints, but apparently those form PyPI. The effect is that after deleting .mypy_cache, a tox run passes once but not twice and complains about `type[P]` instead that does not exist in the source code anymore.

Not sure if this is a Mypy bug or whether I'm holding it wrong…